### PR TITLE
Properly retrieve translations from `strings.yaml`

### DIFF
--- a/server/i18n.ts
+++ b/server/i18n.ts
@@ -63,9 +63,9 @@ const STUDIO_STRINGS = IS_PROD ? {} : loadYAML(STUDIO_DIR + '/translations/strin
 
 // We load the files with all translated UI strings.
 const TRANSLATIONS: Record<string, Record<string, string>> = {};
-for (const locale of Object.keys(AVAILABLE_LOCALES)) {
-  if (locale === 'en') continue;
-  TRANSLATIONS[locale] = loadCombinedYAML(`translations/${locale}/messages.yaml`) as Record<string, string>;
+for (const locale of AVAILABLE_LOCALES) {
+  if (locale.id === 'en') continue;
+  TRANSLATIONS[locale.id] = loadCombinedYAML(`translations/${locale.id}/strings.yaml`) as Record<string, string>;
 }
 
 export function translate(locale: string, str: string, args: string[] = []) {


### PR DESCRIPTION
from my understanding of the [translation process](https://github.com/mathigon/studio/blob/main/build/tools/translate.js#L32-L39), translated phrases are  saved in `translations/<locale>/strings.yaml`.

however, looking at the [code that loads the translations](https://github.com/mathigon/studio/blob/main/server/i18n.ts#L68), it appears to be mistakenly trying to load them from `translations/<locale>/messages.yaml` (instead of `strings.yaml`). thus, the translations are never loaded/available.

in addition, the [`AVAILABLE_LOCALES` appears to be an array of Objects](https://github.com/mathigon/studio/blob/main/server/i18n.ts#L25), so when [accessing the keys](https://github.com/mathigon/studio/blob/main/server/i18n.ts#L66) it returns the array indexes (i.e., `0`, `1`, etc.) instead of the expected [language id](https://github.com/mathigon/studio/blob/main/server/i18n.ts#L67).

this PR attempts to resolve these two issues so translations are properly loaded and rendered. feel free to ignore/close this PR if my understanding of the translation process is incorrect or if i am missing something.

- **before**:

![image](https://user-images.githubusercontent.com/13156555/128582846-4feaa1a1-1615-4b02-9e5b-004ee4bd6b9f.png)

- **after**:

![image](https://user-images.githubusercontent.com/13156555/128582898-55300d80-88e0-41cf-9c3b-d00af5d93822.png)
