### PR TITLE
Add 'path' and 'fs' to external

### DIFF
--- a/build/assets.js
+++ b/build/assets.js
@@ -131,7 +131,7 @@ async function bundleScripts(srcPath, destPath, minify = false, watch = false, n
     platform: 'browser',
     format: 'iife',
     plugins: [pugPlugin, externalPlugin],
-    external: ['vue'],
+    external: ['vue', 'path', 'fs'],
     target: ['es2016'],
     metafile: watch,
     write: false,


### PR DESCRIPTION
Required for mathigon.org to compile successfully when importing box2d-wasm.