### PR TITLE
Update to handle same page anchors

### DIFF
--- a/build/markdown/renderer.js
+++ b/build/markdown/renderer.js
@@ -117,16 +117,13 @@ module.exports.getRenderer = function(metadata, directory, locale='en') {
       return `<strong class="pill ${colour}">${text}</strong>`;
     }
 
-    if (href.startsWith('#') || href.includes(CONFIG.domain)) {
-      return `<a href="${href}">${text}</a>`;
-    }
-
     const href1 = entities.decode(href);
     if (href1.startsWith('->')) {
       return `<x-target class="step-target pill" to="${href1.slice(2).replace(/_/g, ' ')}">${text}</x-target>`;
     }
 
-    return `<a href="${href}" target="_blank">${text}</a>`;
+    const newWindow = !href.startsWith('#') && !href.includes(CONFIG.domain)
+    return `<a href="${href}"${newWindow ? ' target="_blank"' : ''}>${text}</a>`;
   };
 
   renderer.codespan = (code) => {

--- a/build/markdown/renderer.js
+++ b/build/markdown/renderer.js
@@ -122,7 +122,7 @@ module.exports.getRenderer = function(metadata, directory, locale='en') {
       return `<x-target class="step-target pill" to="${href1.slice(2).replace(/_/g, ' ')}">${text}</x-target>`;
     }
 
-    const newWindow = !href.startsWith('#') && !href.includes(CONFIG.domain)
+    const newWindow = !href.startsWith('#') && !href.includes(CONFIG.domain);
     return `<a href="${href}"${newWindow ? ' target="_blank"' : ''}>${text}</a>`;
   };
 

--- a/build/markdown/renderer.js
+++ b/build/markdown/renderer.js
@@ -11,7 +11,7 @@ const entities = require('html-entities');
 
 const {Expression} = require('@mathigon/hilbert');
 const {makeTexPlaceholder} = require('./mathjax');
-const {warning} = require('../utilities');
+const {CONFIG, warning} = require('../utilities');
 
 
 // -----------------------------------------------------------------------------
@@ -115,6 +115,10 @@ module.exports.getRenderer = function(metadata, directory, locale='en') {
     if (href.startsWith('pill:')) {
       const colour = href.slice(5);
       return `<strong class="pill ${colour}">${text}</strong>`;
+    }
+
+    if (href.startsWith('#') || href.includes(CONFIG.domain)) {
+      return `<a href="${href}">${text}</a>`;
     }
 
     const href1 = entities.decode(href);


### PR DESCRIPTION
Hello, I work on the team that is currently developing the Qiskit textbook, and we have the need for same page links. 

This PR updates the renderer to allow links without targeting a new window:
- anchor links that utilize `#` in their `href` attribute
- anchor links that point to the same domain


And with this being my first PR for this project, I'm more than happy to answer any questions to clarify the use case.


Thank you
