### PR TITLE
Fix IBMid oauth configuration

### DIFF
--- a/server/data/oauth.yaml
+++ b/server/data/oauth.yaml
@@ -41,14 +41,13 @@ microsoft:
 
 ibm:
   name: IBM
-  authorizeUrl: https://iam.cloud.ibm.com/identity/authorize
-  accessUrl: https://iam.cloud.ibm.com/identity/token
-  profileUrl: https://user-management.cloud.ibm.com/v2/accounts/{account_id}/users/{iam_id}
+  authorizeUrl: https://login.ibm.com/oidc/endpoint/default/authorize
+  accessUrl: https://login.ibm.com/oidc/endpoint/default/token
+  profileUrl: https://login.ibm.com/oidc/endpoint/default/userinfo
   profileMethod: GET
-  scope: user-management.user.update
+  scope: openid profile email
   profile:
-    id: ${user_id}
-    firstName: ${firstname}
-    lastName: ${lastname}
+    id: ${sub}
+    firstName: ${given_name}
+    lastName: ${family_name}
     email: ${email}
-    picture: ${photo}


### PR DESCRIPTION
From #108 I open this PR fixing the IBMid configuration. The current configuration is using the IBM Cloud IAM service for authenticate users to manage services and other resources inside IBM Cloud. The IBMid is an SSO service provided by IBM for general purpose. We have similar configurations in other libraries like [purest](https://github.com/simov/purest/blob/1d6515f649473ae52ca49961beec971e709306c1/config/providers.json#L1228) in case you want to confirm the change.

I have one doubt from this PR about the `id` parameter that I don't know exactly what expect there. I added the `sub` parameter because is the **unique id** from the **issuer** but I don't know exactly if this is what we expect to store in the variable.

