### PR TITLE
Fix mgon-secrets

### DIFF
--- a/build/secrets.js
+++ b/build/secrets.js
@@ -30,7 +30,7 @@ const path = require('path');
     const clientId = argv[`${k}ClientId`];
     const clientSecret = argv[`${k}ClientSecret`];
     if (clientId) config.accounts.oAuth[k].clientId = clientId;
-    if (clientSecret) config.accounts.oAuth[k].clientId = clientSecret;
+    if (clientSecret) config.accounts.oAuth[k].clientSecret = clientSecret;
   }
 
   await writeFile(src, yaml.dump(config));


### PR DESCRIPTION
Using `mgon-secrets` to update the _config.yml_ doesn't work when you try to update the `clientSecret` of a provider. This fix would solve the problem.