### PR TITLE
Fix index in ProgressSchema

### DIFF
--- a/server/models/progress.ts
+++ b/server/models/progress.ts
@@ -85,7 +85,7 @@ const ProgressSchema = new Schema<ProgressDocument, ProgressModel>({
   messages: [{content: String, kind: {type: String, default: 'hint'}}]
 }, {timestamps: true});
 
-ProgressSchema.index({user: 1, course: 1}, {unique: true});
+ProgressSchema.index({userId: 1, courseId: 1}, {unique: true});
 
 ProgressSchema.virtual('activeSection').get(function(this: ProgressDocument) {
   const course = getCourse(this.courseId, 'en')!;


### PR DESCRIPTION
We found a problem storing the progress of a section. Configuring the indexes with the `courseId` and `userId` fields fixed the problem. Let us know if this change is not correct!